### PR TITLE
Use the protocol-relative url for the fonts

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css?family=Comfortaa");
+@import url("//fonts.googleapis.com/css?family=Comfortaa");
 
 .logo-wrapper {
     font-family: "ComfortaaRegular","sans-serif" !important;


### PR DESCRIPTION
so we don't produce a warning or error when loaded from https
