### PR TITLE
Make it bigger.

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -33,7 +33,7 @@
     position: absolute;
     top: 0px;
     left: 0px;
-    height: 100%;
+    height: calc(100% - 40px);  // Leave room for the footer.
     width: 100%;
     padding: 0px;
 }

--- a/css/site.css
+++ b/css/site.css
@@ -15,10 +15,27 @@
     text-indent: -9999px;
 }
 
+#details-container {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 450px;
+    background-color: rgba(255, 255, 255, 0.85);
+    padding: 15px;
+    padding-top: 0px;
+    margin-top: -10px;
+    z-index: 100;
+    border-radius: 5px;
+}
+
 .hero-unit {
-    height: 600px;
-    margin-bottom: -10px;
-    padding: 5px;
+    z-index: 99;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    height: 100%;
+    width: 100%;
+    padding: 0px;
 }
 
 #mainvis {

--- a/css/site.css
+++ b/css/site.css
@@ -33,7 +33,7 @@
     position: absolute;
     top: 0px;
     left: 0px;
-    height: calc(100% - 40px);  // Leave room for the footer.
+    height: calc(100% - 40px);  /* Leave room for the footer. */
     width: 100%;
     padding: 0px;
 }

--- a/index.html
+++ b/index.html
@@ -20,33 +20,25 @@
 
   <body onload="init();">
     <div id="wrap" class="container-fluid">
-      <div class="row-fluid">
-        <div class="col-md-12">
-          <h1 class="logo-wrapper"><span class="logo">Fedora</span>apps</h1>
-        </div>
+      <div id="details-container">
+        <h1 class="logo-wrapper"><span class="logo">Fedora</span>apps</h1>
+        <div id="details">
+        </div><!--/.well -->
       </div>
-      <div class="row-fluid">
-        <div class="col-md-3">
-          <div id="details">
-          </div><!--/.well -->
-        </div><!--/span-->
 
-        <div class="col-md-7">
-          <div class="hero-unit">
-            <div id="mainvis"></div>
-            <noscript>
-              <iframe name="noscript-fallback" width="100%" height="100%"
-                src="apps-yaml.html"></iframe>
-            </noscript>
-          </div>
-        </div> <!--span7-->
+      <div class="hero-unit">
+        <div id="mainvis"></div>
+        <noscript>
+          <iframe name="noscript-fallback" width="100%" height="100%"
+            src="apps-yaml.html"></iframe>
+        </noscript>
+      </div>
 
-      </div> <!-- row-fluid -->
     </div><!--/.fluid-container-->
 
     <div id="footer">
         <p class="text-muted credit">
-            ©2012 - 2014 Red Hat, Inc.,
+            ©2012 - 2015 Red Hat, Inc.,
             <a href="http://threebean.org">Ralph Bean</a>.
             You can get the source <a href="http://github.com/fedora-infra/apps.fp.o">
               from the github repo</a>.

--- a/js/graph.js
+++ b/js/graph.js
@@ -46,6 +46,8 @@ function init() {
         //Where to append the visualization
         injectInto: 'mainvis',
 
+        levelDistance: 175,  // Default is 100
+
         //Set Node and Edge styles.
         Node: {
             color: DARK_BLUE,
@@ -53,7 +55,7 @@ function init() {
 
         Edge: {
             color: LIGHT_BLUE,
-            lineWidth:2.5
+            lineWidth: 2.5
         },
 
         onBeforeCompute: function(node){
@@ -115,11 +117,11 @@ function init() {
             style.color = BLACK;
 
             if (node._depth == 0) {
-                style.fontSize = "1.5em";
+                style.fontSize = "2.5em";
             } else if (node._depth <= 1) {
-                style.fontSize = "1.1em";
+                style.fontSize = "1.7em";
             } else if(node._depth >= 2){
-                style.fontSize = "0.8em";
+                style.fontSize = "1.2em";
             }
 
             var left = parseInt(style.left);


### PR DESCRIPTION
The key piece is that ``levelDistance: 175,`` line.  That's what
increases the distance between each level of the tree and makes it all
bigger. Everything else is just a css change to accomodate that.

The divs are now no-longer in the 'flow', but are absolutely positioned
which I now think looks better.  The text details div also now has a
white semitransparent background so that the graph can slide under it
and not look weird or mess up the text.  Better use of screen
real-estate, imho.

Fixes #30.