### PR TITLE
Correct Taiga url

### DIFF
--- a/data/apps.yaml
+++ b/data/apps.yaml
@@ -540,7 +540,7 @@ children:
     -   name:   Taiga
         data:
             icon:   taiga.png
-            url:    http://taiga.fedorainfracloud.org/
+            url:    http://taiga.io
             description: >
                  Taiga is a very pretty project management platform that we've
                  been messing around with.  Feel free to use it.  We backup the


### PR DESCRIPTION
It looks like Tiaga moved to http://tiaga.io so the current url fails.
